### PR TITLE
Fix code for mp3 to wav conversion

### DIFF
--- a/client/tts.py
+++ b/client/tts.py
@@ -83,9 +83,8 @@ class AbstractMp3TTSEngine(AbstractTTSEngine):
                 wav.writeframes(frame)
                 frame = mf.read()
             wav.close()
-            wavread = wave.open(f, mode='rb')
-            data = wavread.readframes()
-            wavread.close()
+            f.seek(0)
+            data = f.read()
         return data
 
 


### PR DESCRIPTION
When I ran the current audio-engine code with google tts engine, I got an error on wavread = wave.open(f, mode='rb'). I get a EOFError.

From what I can read, you write a wav file from the mp3 and then want to load the wav data and then return it.
I think there are two issues:
- you need to do a fseek(0) on f to go back at the start of the file
- you need to return the "full" content of the wav file, not just the frames (later in your code, you write that data back into a file and load it using wave.open => you need not just the frames, but the header as well).

Tested on my RPI, gTTS works after this change.
